### PR TITLE
feat: [US14] - add support for tour waypoints

### DIFF
--- a/backend/src/main/java/com/c15tour/backend/entity/Tour.java
+++ b/backend/src/main/java/com/c15tour/backend/entity/Tour.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import lombok.Data;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "tours")
@@ -31,5 +33,8 @@ public class Tour {
 
     @Column(name = "created_at", insertable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    @OneToMany(mappedBy = "tour", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Waypoint> waypoints = new ArrayList<>();
 
 }

--- a/backend/src/main/java/com/c15tour/backend/entity/Waypoint.java
+++ b/backend/src/main/java/com/c15tour/backend/entity/Waypoint.java
@@ -1,0 +1,28 @@
+package com.c15tour.backend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Data
+@Table(name = "waypoints")
+public class Waypoint {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private Double latitude;
+
+    @Column(nullable = false)
+    private Double longitude;
+
+    @Column(name = "order_index", nullable = false)
+    private Integer orderIndex;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "tour_id", nullable = false)
+    private Tour tour;
+
+}

--- a/backend/src/main/java/com/c15tour/backend/mapper/TourMapper.java
+++ b/backend/src/main/java/com/c15tour/backend/mapper/TourMapper.java
@@ -1,10 +1,16 @@
 package com.c15tour.backend.mapper;
 
 import com.c15tour.backend.entity.Tour;
+import com.c15tour.backend.entity.Waypoint;
 import com.c15tour.model.Coordinates;
 import com.c15tour.model.TourCreateRequest;
 import com.c15tour.model.TourResponse;
 import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 public class TourMapper {
@@ -22,6 +28,22 @@ public class TourMapper {
         if (request.getEndPoint() != null) {
             tour.setEndLatitude(request.getEndPoint().getLatitude());
             tour.setEndLongitude(request.getEndPoint().getLongitude());
+        }
+
+        if (request.getWaypoints() != null) {
+            List<Waypoint> waypointEntities = new ArrayList<>();
+            for (int i = 0; i < request.getWaypoints().size(); i++) {
+                Coordinates coords = request.getWaypoints().get(i);
+
+                Waypoint wp = new Waypoint();
+                wp.setLatitude(coords.getLatitude());
+                wp.setLongitude(coords.getLongitude());
+                wp.setOrderIndex(i); // important de garder l'ordre
+                wp.setTour(tour);
+
+                waypointEntities.add(wp);
+            }
+            tour.setWaypoints(waypointEntities);
         }
 
         return tour;
@@ -42,6 +64,19 @@ public class TourMapper {
         end.setLatitude(entity.getEndLatitude());
         end.setLongitude(entity.getEndLongitude());
         response.setEndPoint(end);
+
+        if (entity.getWaypoints() != null) {
+            List<Coordinates> waypointDtos = entity.getWaypoints().stream()
+                    .sorted(Comparator.comparingInt(Waypoint::getOrderIndex))
+                    .map(wp -> {
+                        Coordinates c = new Coordinates();
+                        c.setLatitude(wp.getLatitude());
+                        c.setLongitude(wp.getLongitude());
+                        return c;
+                    })
+                    .collect(Collectors.toList());
+            response.setWaypoints(waypointDtos);
+        }
 
         return response;
     }

--- a/backend/src/main/resources/db/migration/V2__Add_Waypoints_Table.sql
+++ b/backend/src/main/resources/db/migration/V2__Add_Waypoints_Table.sql
@@ -1,0 +1,9 @@
+CREATE TABLE IF NOT EXISTS waypoints (
+    id SERIAL PRIMARY KEY,
+    tour_id INTEGER NOT NULL REFERENCES tours(id) ON DELETE CASCADE,
+    latitude DOUBLE PRECISION NOT NULL,
+    longitude DOUBLE PRECISION NOT NULL,
+    order_index INTEGER NOT NULL
+    );
+
+CREATE INDEX idx_waypoints_tour_id ON waypoints(tour_id);

--- a/backend/src/test/java/com/c15tour/backend/controller/TourControllerIntegrationTest.java
+++ b/backend/src/test/java/com/c15tour/backend/controller/TourControllerIntegrationTest.java
@@ -1,0 +1,142 @@
+package com.c15tour.backend.controller;
+
+import com.c15tour.backend.entity.Tour;
+import com.c15tour.backend.repository.TourRepository;
+import com.c15tour.model.Coordinates;
+import com.c15tour.model.TourCreateRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.testcontainers.service.connection.ServiceConnection;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.util.List;
+
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@Testcontainers
+public class TourControllerIntegrationTest {
+
+    @Container
+    @ServiceConnection
+    static PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:16-alpine");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private TourRepository tourRepository;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private TourCreateRequest createTourRequest(String name) {
+        TourCreateRequest request = new TourCreateRequest();
+        request.setName(name);
+
+        Coordinates start = new Coordinates();
+        start.setLatitude(47.2184);
+        start.setLongitude(-1.5536);
+        request.setStartPoint(start);
+
+        Coordinates end = new Coordinates();
+        end.setLatitude(48.8566);
+        end.setLongitude(2.3522);
+        request.setEndPoint(end);
+
+        request.setWaypoints(List.of());
+
+        return request;
+    }
+
+    private Tour createTourEntity(String name) {
+        Tour tour = new Tour();
+        tour.setName(name);
+        tour.setStartLatitude(10.0);
+        tour.setStartLongitude(20.0);
+        tour.setEndLatitude(30.0);
+        tour.setEndLongitude(40.0);
+        return tourRepository.save(tour);
+    }
+
+    @Test
+    void createTour_ShouldReturnCreatedTour() throws Exception {
+        TourCreateRequest request = createTourRequest("Trip to Nantes");
+
+        mockMvc.perform(post("/tours")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.name", is("Trip to Nantes")))
+                .andExpect(jsonPath("$.startPoint.latitude", is(47.2184)));
+    }
+
+    @Test
+    void getAllTours_ShouldReturnList() throws Exception {
+        createTourEntity("Tour 1");
+        createTourEntity("Tour 2");
+
+        mockMvc.perform(get("/tours"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$", hasSize(greaterThanOrEqualTo(2))))
+                .andExpect(jsonPath("$[*].name", hasItem("Tour 1")));
+    }
+
+    @Test
+    void getTourById_ShouldReturnTour() throws Exception {
+        Tour savedTour = createTourEntity("Single Tour");
+
+        mockMvc.perform(get("/tours/" + savedTour.getId()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id", is(savedTour.getId().intValue())))
+                .andExpect(jsonPath("$.name", is("Single Tour")));
+    }
+
+    @Test
+    void getTourById_WhenNotFound_ShouldReturn404() throws Exception {
+        mockMvc.perform(get("/tours/999999"))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    void updateTour_ShouldReturnUpdatedTour() throws Exception {
+        Tour savedTour = createTourEntity("Old Name");
+
+        TourCreateRequest updateRequest = createTourRequest("New Name");
+
+        mockMvc.perform(put("/tours/" + savedTour.getId())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(updateRequest)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name", is("New Name")));
+    }
+
+    @Test
+    void deleteTour_ShouldRemoveTour() throws Exception {
+        Tour savedTour = createTourEntity("To Delete");
+
+        mockMvc.perform(delete("/tours/" + savedTour.getId()))
+                .andExpect(status().isNoContent());
+
+        assertFalse(tourRepository.findById(savedTour.getId()).isPresent());
+    }
+
+    @Test
+    void deleteTour_WhenNotFound_ShouldReturn404() throws Exception {
+        mockMvc.perform(delete("/tours/999999"))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/contract/src/main/resources/openapi.yaml
+++ b/contract/src/main/resources/openapi.yaml
@@ -173,6 +173,11 @@ components:
           $ref: '#/components/schemas/Coordinates'
         endPoint:
           $ref: '#/components/schemas/Coordinates'
+        waypoints:
+          type: array
+          description: "List of intermediate stops"
+          items:
+            $ref: '#/components/schemas/Coordinates'
 
     TourResponse:
       type: object
@@ -188,3 +193,7 @@ components:
           $ref: '#/components/schemas/Coordinates'
         endPoint:
           $ref: '#/components/schemas/Coordinates'
+        waypoints:
+            type: array
+            items:
+                $ref: '#/components/schemas/Coordinates'


### PR DESCRIPTION
# feat: Implement Waypoints for Tours

## Description
Adds support for intermediate waypoints in Tours, enabling multi-step itineraries from API to Database.

## Changes
* **API:** Added `waypoints` list to `openapi.yaml` contract.
* **Database:** Created `waypoints` table via V2 Flyway migration.
* **Backend:** Implemented `Waypoint` entity, updated `Tour` relationship, and adapted `TourMapper`.
* **Testing:** Added Testcontainers for safe integration testing of persistence.

## Related Stories
* [SUB] [US14] Update API Contract
* [SUB] [US14] Create Waypoints Table
* [SUB] [US14] Implement Persistence Logic
* [SUB] [US14] Integration Test