### PR TITLE
feat: [US15] - added osrm to docker env

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ target/
 *.rar
 
 
+
+osrm-data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,10 @@ services:
       SPRING_DATASOURCE_PASSWORD: devpassword
       # Autoriser les appels venant du frontend
       ALLOWED_ORIGINS: "http://localhost,http://localhost:5173"
+      OSRM_API_URL: "http://osrm-backend:5000"
     depends_on:
       - postgres
+      - osrm-backend
     networks:
       - c15-network
 
@@ -59,6 +61,20 @@ services:
       - "80:80" # Site accessible sur http://localhost
     depends_on:
       - backend
+    networks:
+      - c15-network
+      
+  # --- 5. OSRM Service (Routing Engine) ---
+  osrm-backend:
+    platform: linux/amd64
+    image: osrm/osrm-backend
+    container_name: c15tour-osrm
+    restart: always
+    ports:
+      - "5001:5000"
+    volumes:
+      - ./osrm-data:/data
+    command: osrm-routed --algorithm ch /data/pays-de-la-loire.osrm
     networks:
       - c15-network
 


### PR DESCRIPTION
**Description :**
Cette MR intègre OSRM dans notre environnement Docker. Cela permet au backend de calculer des itinéraires (distance, durée, géométrie) localement, sans dépendre d'API payantes externes ni de connexion internet.

Nous utilisons actuellement la carte régionale des Pays de la Loire pour le développement afin de minimiser l'utilisation de la RAM, mais la configuration supporte des cartes nationales complètes pour la production.

**Changements Clés :**
``docker-compose.yml`` :

* Ajout du service osrm-backend tournant sur le port 5001 (hôte) / 5000 (interne).

* Configuration du volume partagé ./osrm-data pour persister les données cartographiques.

* Ajout de la variable d'environnement OSRM_API_URL au service backend pour la communication interne.

**Git :**

Mise à jour du .gitignore pour exclure le dossier de données cartographiques volumineux (osrm-data/).

Comment lancer (Requis pour les Reviewers) :
Puisque les données cartographiques ne sont pas commitées sur Git, il faut effectuer une installation unique avant de lancer docker-compose up.

Créer le dossier de données :

**Bash**

``mkdir -p c15-tour-backend/osrm-data``
Télécharger la carte (Pays de la Loire) :

Télécharger pays-de-la-loire-latest.osm.pbf depuis Geofabrik et placez-le dans osrm-data/.

Ou lancez : ``curl -L https://download.geofabrik.de/europe/france/pays-de-la-loire-latest.osm.pbf -o c15-tour-backend/osrm-data/pays-de-la-loire.osm.pbf``

Pré-traiter la carte (Extraction & Contraction) : Lancer ces commandes depuis le dossier c15-tour-backend :

**Bash**

``docker run -t -v "${PWD}/osrm-data:/data" osrm/osrm-backend osrm-extract -p /opt/car.lua /data/pays-de-la-loire.osm.pbf``
``docker run -t -v "${PWD}/osrm-data:/data" osrm/osrm-backend osrm-contract /data/pays-de-la-loire.osrm``
Démarrer la stack :

**Bash**

``docker-compose up -d``
**Vérification :
Accédez à l'API de routage directement dans votre navigateur : http://localhost:5001/route/v1/driving/-1.5536,47.2184;-0.5518,47.4711?overview=false

Résultat attendu : Une réponse JSON contenant la distance et la durée.


--- 
**Notes Techniques :
Port : Mappé sur 5001 en localhost pour éviter les conflits avec AirPlay sur macOS (port 5000). La communication interne reste sur le port 5000.

RAM : La carte "Pays de la Loire" nécessite ~400Mo de RAM. La carte complète de la France nécessiterait ~6-8Go.