### PR TITLE
feat:#37 - ajouter instructions de navigation dans le segment

### DIFF
--- a/backend/src/main/java/com/c15tour/backend/controller/TourController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/TourController.java
@@ -122,7 +122,7 @@ public class TourController implements ToursApi {
                     .collect(Collectors.toList());
 
             // On appelle OSRM
-            OSRMResponse response = routingService.calculateRoute(coords);
+            OSRMResponse response = routingService.calculateRoute(coords, true);
 
             // On met à jour le segment
             if (response != null && response.routes() != null && !response.routes().isEmpty()) {
@@ -140,6 +140,15 @@ public class TourController implements ToursApi {
                 try {
                     String geometryJson = objectMapper.writeValueAsString(route.geometry());
                     segment.setGeometry(geometryJson);
+
+                    if (route.legs() != null) {
+                        List<OSRMResponse.Step> allSteps = route.legs().stream()
+                                .flatMap(leg -> leg.steps() != null ? leg.steps().stream() : java.util.stream.Stream.empty())
+                                .collect(Collectors.toList());
+
+                        String stepsJson = objectMapper.writeValueAsString(allSteps);
+                        segment.setSteps(stepsJson);
+                    }
                 } catch (JsonProcessingException e) {
                     e.printStackTrace();
                 }

--- a/backend/src/main/java/com/c15tour/backend/entity/Segment.java
+++ b/backend/src/main/java/com/c15tour/backend/entity/Segment.java
@@ -38,6 +38,9 @@ public class Segment {
     @JdbcTypeCode(SqlTypes.JSON)
     private String geometry;
 
+    @Column(columnDefinition = "TEXT")
+    private String steps;
+
     @Column(name = "order_index", nullable = false)
     private Integer orderIndex;
 }

--- a/backend/src/main/java/com/c15tour/backend/mapper/TourMapper.java
+++ b/backend/src/main/java/com/c15tour/backend/mapper/TourMapper.java
@@ -96,6 +96,8 @@ public class TourMapper {
         response.setDuration(segment.getDuration() != null ? segment.getDuration().longValue() : 0L);
         response.setGeometry(segment.getGeometry());
 
+        response.setSteps(segment.getSteps());
+
         if (segment.getWaypoints() != null) {
             List<Waypoints> waypointDtos = segment.getWaypoints().stream()
                     .sorted(Comparator.comparingInt(Waypoint::getOrderIndex))

--- a/backend/src/main/java/com/c15tour/backend/service/osrm/OSRMResponse.java
+++ b/backend/src/main/java/com/c15tour/backend/service/osrm/OSRMResponse.java
@@ -18,8 +18,7 @@ public record OSRMResponse(
           Double duration,
           String weight_name,
           Double weight
-    ){
-    }
+    ){}
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public record Geometry(

--- a/backend/src/main/resources/db/migration/V8__Add_Steps_To_Segments.sql
+++ b/backend/src/main/resources/db/migration/V8__Add_Steps_To_Segments.sql
@@ -1,0 +1,1 @@
+ALTER TABLE segment ADD COLUMN steps TEXT;

--- a/contract/src/main/resources/openapi.yaml
+++ b/contract/src/main/resources/openapi.yaml
@@ -240,6 +240,9 @@ components:
         geometry:
           type: string
           description: Geometry of the OSRM Response on type JSON
+        steps:
+          type: string
+          description: List of navigation steps and maneuvers (JSON string)
         waypoints:
           type: array
           description: List of the points which compose the segment


### PR DESCRIPTION
This pull request enhances the tour routing functionality by adding support for storing and returning navigation steps for each segment in a tour. The changes affect the backend service, database schema, data mapping, and API contract.

**Backend and Data Model Enhancements:**

* The `Segment` entity now includes a new `steps` field to store navigation steps as a JSON string.
* The database schema is updated to add a `steps` column of type `TEXT` to the `segment` table.

**Routing and Data Processing:**

* The routing service call in `TourController` now requests step-by-step navigation from OSRM, and the resulting steps are serialized and saved to the new `steps` field in each segment. [[1]](diffhunk://#diff-1ba9755ae1b52c6a6a24a95f63d4f1346d6f25cffacf7ab8903d746121312b0dL125-R125) [[2]](diffhunk://#diff-1ba9755ae1b52c6a6a24a95f63d4f1346d6f25cffacf7ab8903d746121312b0dR143-R151)

**API and Data Mapping:**

* The `TourMapper` is updated to include the `steps` field in the `SegmentResponse` DTO, ensuring clients receive navigation steps in API responses.
* The OpenAPI specification is updated to document the new `steps` property in the segment schema, describing it as a JSON string with navigation steps and maneuvers.

**Minor Code Cleanups:**

* Minor formatting adjustment in the `OSRMResponse.Route` record for consistency.