### PR TITLE
fix: skip CI and sync on release-please bot merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   test:
     name: Build & Test
     runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request' ||
+      !contains(github.event.head_commit.message, 'release-please--branches--main')
 
     steps:
       - name: Checkout

--- a/.github/workflows/sync-main-to-dev.yml
+++ b/.github/workflows/sync-main-to-dev.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    if: "!contains(github.event.head_commit.message, 'release-please--branches--main')"
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Chaque merge de PR release-please sur `main` déclenchait en cascade CI + Release + Sync (3 runs), et comme release-please enchaîne 2 PR par cycle de release (la release elle-même + le SNAPSHOT suivant), on se retrouvait avec 40+ runs en quelques minutes pour de simples bumps de version dans `pom.xml`.

## Changements

- **`.github/workflows/ci.yml`** — ajout d'une condition `if` pour sauter le job si le push vient d'un merge de branche `release-please--branches--main` (sauf pour les événements `pull_request`)
- **`.github/workflows/sync-main-to-dev.yml`** — même condition : ne crée pas de PR de sync quand c'est release-please qui pousse sur main

## Comportement

1. Un commit réel arrive sur `main` (merge d'une feature via `dev`) → CI + Release + Sync s'exécutent normalement
2. Release-please merge son PR de version sur `main` → CI et Sync sont skippés, seul le workflow Release tourne (release-please a besoin de s'exécuter pour créer la prochaine PR)

## Tests à effectuer

- [ ] Merger une feature sur `dev` → CI doit tourner
- [ ] Laisser release-please merger sa PR sur `main` → CI et Sync doivent afficher "skipped"
- [ ] Vérifier que le workflow Release continue de tourner normalement sur les commits release-please