### PR TITLE
feat(auth): email-based auth with change/forgot/reset-password + Mailjet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+# Copy this file to .env and fill in your values.
+# The .env file is gitignored — never commit it.
+
+MAILJET_API_KEY=your_api_key_here
+MAILJET_SECRET_KEY=your_secret_key_here
+FRONTEND_URL=http://localhost

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -43,6 +43,10 @@
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -28,6 +28,11 @@
 	</properties>
 	<dependencies>
 		<dependency>
+			<groupId>me.paulschwarz</groupId>
+			<artifactId>spring-dotenv</artifactId>
+			<version>4.0.0</version>
+		</dependency>
+		<dependency>
 			<groupId>com.c15tour</groupId>
 			<artifactId>contract</artifactId>
 			<version>${project.version}</version>

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -20,6 +20,8 @@ import java.util.UUID;
 @RequestMapping("/auth")
 public class AuthController {
 
+    private static final String MESSAGE_KEY = "message";
+
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -91,7 +93,7 @@ public class AuthController {
         user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
         userRepository.save(user);
 
-        return ResponseEntity.ok(Map.of("message", "Password updated successfully"));
+        return ResponseEntity.ok(Map.of(MESSAGE_KEY, "Password updated successfully"));
     }
 
     @PostMapping("/forgot-password")
@@ -109,7 +111,7 @@ public class AuthController {
             mailjetEmailService.sendPasswordResetEmail(user.getEmail(), resetUrl);
         }
 
-        return ResponseEntity.ok(Map.of("message", "If that email exists, a reset link has been sent"));
+        return ResponseEntity.ok(Map.of(MESSAGE_KEY, "If that email exists, a reset link has been sent"));
     }
 
     @PostMapping("/reset-password")
@@ -132,7 +134,7 @@ public class AuthController {
         user.setResetTokenExpiry(null);
         userRepository.save(user);
 
-        return ResponseEntity.ok(Map.of("message", "Password reset successfully"));
+        return ResponseEntity.ok(Map.of(MESSAGE_KEY, "Password reset successfully"));
     }
 
     public record LoginRequest(String email, String password) {}

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -60,7 +60,9 @@ public class AuthController {
             return ResponseEntity.badRequest().body(Map.of("error", "Email and password are required"));
         }
 
-        if (!request.email().matches("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")) {
+        int atIdx = request.email().indexOf('@');
+        if (atIdx <= 0 || atIdx >= request.email().length() - 1
+                || request.email().lastIndexOf('.') <= atIdx) {
             return ResponseEntity.badRequest().body(Map.of("error", "Invalid email format"));
         }
 

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -28,6 +28,7 @@ import java.util.UUID;
 public class AuthController {
 
     private static final String MESSAGE_KEY = "message";
+    private static final String ROLE_ADMIN = ROLE_ADMIN;
     private static final int MIN_PASSWORD_LENGTH = 8;
 
     private final JwtUtils jwtUtils;
@@ -53,7 +54,7 @@ public class AuthController {
     public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
         Optional<User> dbUser = userRepository.findByEmail(request.email());
         if (dbUser.isPresent() && passwordEncoder.matches(request.password(), dbUser.get().getPasswordHash())) {
-            String token = jwtUtils.generateToken(dbUser.get().getEmail(), "ADMIN");
+            String token = jwtUtils.generateToken(dbUser.get().getEmail(), ROLE_ADMIN);
             return ResponseEntity.ok(Map.of("token", token));
         }
 
@@ -73,7 +74,7 @@ public class AuthController {
         user.setPasswordHash(passwordEncoder.encode(request.password()));
         userRepository.save(user);
 
-        String token = jwtUtils.generateToken(user.getEmail(), "ADMIN");
+        String token = jwtUtils.generateToken(user.getEmail(), ROLE_ADMIN);
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("token", token));
     }
 
@@ -97,7 +98,7 @@ public class AuthController {
         user.setPasswordChangedAt(Instant.now().getEpochSecond());
         userRepository.save(user);
 
-        String newToken = jwtUtils.generateToken(user.getEmail(), "ADMIN");
+        String newToken = jwtUtils.generateToken(user.getEmail(), ROLE_ADMIN);
         return ResponseEntity.ok(Map.of(
                 MESSAGE_KEY, "Password updated successfully",
                 "token", newToken));

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -28,7 +28,7 @@ import java.util.UUID;
 public class AuthController {
 
     private static final String MESSAGE_KEY = "message";
-    private static final String ROLE_ADMIN = ROLE_ADMIN;
+    private static final String ROLE_ADMIN = "ADMIN";
     private static final int MIN_PASSWORD_LENGTH = 8;
 
     private final JwtUtils jwtUtils;

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -60,6 +60,10 @@ public class AuthController {
             return ResponseEntity.badRequest().body(Map.of("error", "Email and password are required"));
         }
 
+        if (!request.email().matches("^[^@\\s]+@[^@\\s]+\\.[^@\\s]+$")) {
+            return ResponseEntity.badRequest().body(Map.of("error", "Invalid email format"));
+        }
+
         if (userRepository.existsByEmail(request.email())) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(Map.of("error", "Email already taken"));
@@ -76,6 +80,10 @@ public class AuthController {
 
     @PostMapping("/change-password")
     public ResponseEntity<?> changePassword(@RequestBody ChangePasswordRequest request, Authentication authentication) {
+        if (request.newPassword() == null || request.newPassword().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "New password is required"));
+        }
+
         String email = authentication.getName();
         Optional<User> dbUser = userRepository.findByEmail(email);
 
@@ -127,6 +135,10 @@ public class AuthController {
         if (user.getResetTokenExpiry() == null || LocalDateTime.now().isAfter(user.getResetTokenExpiry())) {
             return ResponseEntity.badRequest()
                     .body(Map.of("error", "Invalid or expired token"));
+        }
+
+        if (request.newPassword() == null || request.newPassword().isBlank()) {
+            return ResponseEntity.badRequest().body(Map.of("error", "New password is required"));
         }
 
         user.setPasswordHash(passwordEncoder.encode(request.newPassword()));

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -3,14 +3,21 @@ package com.c15tour.backend.controller;
 import com.c15tour.backend.entity.User;
 import com.c15tour.backend.repository.UserRepository;
 import com.c15tour.backend.security.JwtUtils;
+import com.c15tour.backend.security.TokenHasher;
 import com.c15tour.backend.service.MailjetEmailService;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
@@ -21,6 +28,7 @@ import java.util.UUID;
 public class AuthController {
 
     private static final String MESSAGE_KEY = "message";
+    private static final int MIN_PASSWORD_LENGTH = 8;
 
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
@@ -42,7 +50,7 @@ public class AuthController {
     }
 
     @PostMapping("/login")
-    public ResponseEntity<?> login(@RequestBody LoginRequest request) {
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest request) {
         Optional<User> dbUser = userRepository.findByEmail(request.email());
         if (dbUser.isPresent() && passwordEncoder.matches(request.password(), dbUser.get().getPasswordHash())) {
             String token = jwtUtils.generateToken(dbUser.get().getEmail(), "ADMIN");
@@ -54,18 +62,7 @@ public class AuthController {
     }
 
     @PostMapping("/register")
-    public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
-        if (request.email() == null || request.email().isBlank()
-                || request.password() == null || request.password().isBlank()) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Email and password are required"));
-        }
-
-        int atIdx = request.email().indexOf('@');
-        if (atIdx <= 0 || atIdx >= request.email().length() - 1
-                || request.email().lastIndexOf('.') <= atIdx) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Invalid email format"));
-        }
-
+    public ResponseEntity<?> register(@Valid @RequestBody RegisterRequest request) {
         if (userRepository.existsByEmail(request.email())) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
                     .body(Map.of("error", "Email already taken"));
@@ -81,11 +78,7 @@ public class AuthController {
     }
 
     @PostMapping("/change-password")
-    public ResponseEntity<?> changePassword(@RequestBody ChangePasswordRequest request, Authentication authentication) {
-        if (request.newPassword() == null || request.newPassword().isBlank()) {
-            return ResponseEntity.badRequest().body(Map.of("error", "New password is required"));
-        }
-
+    public ResponseEntity<?> changePassword(@Valid @RequestBody ChangePasswordRequest request, Authentication authentication) {
         String email = authentication.getName();
         Optional<User> dbUser = userRepository.findByEmail(email);
 
@@ -101,23 +94,30 @@ public class AuthController {
         }
 
         user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
+        user.setPasswordChangedAt(Instant.now().getEpochSecond());
         userRepository.save(user);
 
-        return ResponseEntity.ok(Map.of(MESSAGE_KEY, "Password updated successfully"));
+        String newToken = jwtUtils.generateToken(user.getEmail(), "ADMIN");
+        return ResponseEntity.ok(Map.of(
+                MESSAGE_KEY, "Password updated successfully",
+                "token", newToken));
     }
 
     @PostMapping("/forgot-password")
-    public ResponseEntity<?> forgotPassword(@RequestBody ForgotPasswordRequest request) {
+    public ResponseEntity<?> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
         Optional<User> dbUser = userRepository.findByEmail(request.email());
 
         if (dbUser.isPresent()) {
             User user = dbUser.get();
-            String token = UUID.randomUUID().toString();
-            user.setResetToken(token);
+            String rawToken = UUID.randomUUID().toString();
+            user.setResetToken(TokenHasher.sha256(rawToken));
             user.setResetTokenExpiry(LocalDateTime.now().plusHours(1));
             userRepository.save(user);
 
-            String resetUrl = frontendUrl + "/reset-password?token=" + token;
+            String resetUrl = UriComponentsBuilder.fromUriString(frontendUrl)
+                    .path("/reset-password")
+                    .queryParam("token", rawToken)
+                    .toUriString();
             mailjetEmailService.sendPasswordResetEmail(user.getEmail(), resetUrl);
         }
 
@@ -125,8 +125,8 @@ public class AuthController {
     }
 
     @PostMapping("/reset-password")
-    public ResponseEntity<?> resetPassword(@RequestBody ResetPasswordRequest request) {
-        Optional<User> dbUser = userRepository.findByResetToken(request.token());
+    public ResponseEntity<?> resetPassword(@Valid @RequestBody ResetPasswordRequest request) {
+        Optional<User> dbUser = userRepository.findByResetToken(TokenHasher.sha256(request.token()));
 
         if (dbUser.isEmpty()) {
             return ResponseEntity.badRequest()
@@ -139,21 +139,31 @@ public class AuthController {
                     .body(Map.of("error", "Invalid or expired token"));
         }
 
-        if (request.newPassword() == null || request.newPassword().isBlank()) {
-            return ResponseEntity.badRequest().body(Map.of("error", "New password is required"));
-        }
-
         user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
         user.setResetToken(null);
         user.setResetTokenExpiry(null);
+        user.setPasswordChangedAt(Instant.now().getEpochSecond());
         userRepository.save(user);
 
         return ResponseEntity.ok(Map.of(MESSAGE_KEY, "Password reset successfully"));
     }
 
-    public record LoginRequest(String email, String password) {}
-    public record RegisterRequest(String email, String password) {}
-    public record ChangePasswordRequest(String currentPassword, String newPassword) {}
-    public record ForgotPasswordRequest(String email) {}
-    public record ResetPasswordRequest(String token, String newPassword) {}
+    public record LoginRequest(
+            @NotBlank @Email String email,
+            @NotBlank String password) {}
+
+    public record RegisterRequest(
+            @NotBlank @Email String email,
+            @NotBlank @Size(min = MIN_PASSWORD_LENGTH) String password) {}
+
+    public record ChangePasswordRequest(
+            @NotBlank String currentPassword,
+            @NotBlank @Size(min = MIN_PASSWORD_LENGTH) String newPassword) {}
+
+    public record ForgotPasswordRequest(
+            @NotBlank @Email String email) {}
+
+    public record ResetPasswordRequest(
+            @NotBlank String token,
+            @NotBlank @Size(min = MIN_PASSWORD_LENGTH) String newPassword) {}
 }

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -3,48 +3,47 @@ package com.c15tour.backend.controller;
 import com.c15tour.backend.entity.User;
 import com.c15tour.backend.repository.UserRepository;
 import com.c15tour.backend.security.JwtUtils;
+import com.c15tour.backend.service.MailjetEmailService;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
 
-    private final String adminUsername;
-    private final String adminPassword;
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+    private final MailjetEmailService mailjetEmailService;
+    private final String frontendUrl;
 
     public AuthController(
-            @Value("${app.security.admin-username}") String adminUsername,
-            @Value("${app.security.admin-password}") String adminPassword,
             JwtUtils jwtUtils,
             UserRepository userRepository,
-            PasswordEncoder passwordEncoder) {
-        this.adminUsername = adminUsername;
-        this.adminPassword = adminPassword;
+            PasswordEncoder passwordEncoder,
+            MailjetEmailService mailjetEmailService,
+            @Value("${app.frontend.url}") String frontendUrl) {
         this.jwtUtils = jwtUtils;
         this.userRepository = userRepository;
         this.passwordEncoder = passwordEncoder;
+        this.mailjetEmailService = mailjetEmailService;
+        this.frontendUrl = frontendUrl;
     }
 
     @PostMapping("/login")
     public ResponseEntity<?> login(@RequestBody LoginRequest request) {
-        Optional<User> dbUser = userRepository.findByUsername(request.username());
+        Optional<User> dbUser = userRepository.findByEmail(request.email());
         if (dbUser.isPresent() && passwordEncoder.matches(request.password(), dbUser.get().getPasswordHash())) {
-            String token = jwtUtils.generateToken(request.username(), "ADMIN");
-            return ResponseEntity.ok(Map.of("token", token));
-        }
-
-        if (adminUsername.equals(request.username()) && adminPassword.equals(request.password())) {
-            String token = jwtUtils.generateToken(adminUsername, "ADMIN");
+            String token = jwtUtils.generateToken(dbUser.get().getEmail(), "ADMIN");
             return ResponseEntity.ok(Map.of("token", token));
         }
 
@@ -54,25 +53,91 @@ public class AuthController {
 
     @PostMapping("/register")
     public ResponseEntity<?> register(@RequestBody RegisterRequest request) {
-        if (request.username() == null || request.username().isBlank()
+        if (request.email() == null || request.email().isBlank()
                 || request.password() == null || request.password().isBlank()) {
-            return ResponseEntity.badRequest().body(Map.of("error", "Username and password are required"));
+            return ResponseEntity.badRequest().body(Map.of("error", "Email and password are required"));
         }
 
-        if (adminUsername.equals(request.username()) || userRepository.existsByUsername(request.username())) {
+        if (userRepository.existsByEmail(request.email())) {
             return ResponseEntity.status(HttpStatus.CONFLICT)
-                    .body(Map.of("error", "Username already taken"));
+                    .body(Map.of("error", "Email already taken"));
         }
 
         User user = new User();
-        user.setUsername(request.username());
+        user.setEmail(request.email());
         user.setPasswordHash(passwordEncoder.encode(request.password()));
         userRepository.save(user);
 
-        String token = jwtUtils.generateToken(request.username(), "ADMIN");
+        String token = jwtUtils.generateToken(user.getEmail(), "ADMIN");
         return ResponseEntity.status(HttpStatus.CREATED).body(Map.of("token", token));
     }
 
-    public record LoginRequest(String username, String password) {}
-    public record RegisterRequest(String username, String password) {}
+    @PostMapping("/change-password")
+    public ResponseEntity<?> changePassword(@RequestBody ChangePasswordRequest request, Authentication authentication) {
+        String email = authentication.getName();
+        Optional<User> dbUser = userRepository.findByEmail(email);
+
+        if (dbUser.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "User not found"));
+        }
+
+        User user = dbUser.get();
+        if (!passwordEncoder.matches(request.currentPassword(), user.getPasswordHash())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "Current password is incorrect"));
+        }
+
+        user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
+        userRepository.save(user);
+
+        return ResponseEntity.ok(Map.of("message", "Password updated successfully"));
+    }
+
+    @PostMapping("/forgot-password")
+    public ResponseEntity<?> forgotPassword(@RequestBody ForgotPasswordRequest request) {
+        Optional<User> dbUser = userRepository.findByEmail(request.email());
+
+        if (dbUser.isPresent()) {
+            User user = dbUser.get();
+            String token = UUID.randomUUID().toString();
+            user.setResetToken(token);
+            user.setResetTokenExpiry(LocalDateTime.now().plusHours(1));
+            userRepository.save(user);
+
+            String resetUrl = frontendUrl + "/reset-password?token=" + token;
+            mailjetEmailService.sendPasswordResetEmail(user.getEmail(), resetUrl);
+        }
+
+        return ResponseEntity.ok(Map.of("message", "If that email exists, a reset link has been sent"));
+    }
+
+    @PostMapping("/reset-password")
+    public ResponseEntity<?> resetPassword(@RequestBody ResetPasswordRequest request) {
+        Optional<User> dbUser = userRepository.findByResetToken(request.token());
+
+        if (dbUser.isEmpty()) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid or expired token"));
+        }
+
+        User user = dbUser.get();
+        if (user.getResetTokenExpiry() == null || LocalDateTime.now().isAfter(user.getResetTokenExpiry())) {
+            return ResponseEntity.badRequest()
+                    .body(Map.of("error", "Invalid or expired token"));
+        }
+
+        user.setPasswordHash(passwordEncoder.encode(request.newPassword()));
+        user.setResetToken(null);
+        user.setResetTokenExpiry(null);
+        userRepository.save(user);
+
+        return ResponseEntity.ok(Map.of("message", "Password reset successfully"));
+    }
+
+    public record LoginRequest(String email, String password) {}
+    public record RegisterRequest(String email, String password) {}
+    public record ChangePasswordRequest(String currentPassword, String newPassword) {}
+    public record ForgotPasswordRequest(String email) {}
+    public record ResetPasswordRequest(String token, String newPassword) {}
 }

--- a/backend/src/main/java/com/c15tour/backend/entity/User.java
+++ b/backend/src/main/java/com/c15tour/backend/entity/User.java
@@ -1,6 +1,7 @@
 package com.c15tour.backend.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Table(name = "users")
@@ -11,14 +12,24 @@ public class User {
     private Long id;
 
     @Column(nullable = false, unique = true)
-    private String username;
+    private String email;
 
     @Column(name = "password_hash", nullable = false)
     private String passwordHash;
 
+    @Column(name = "reset_token")
+    private String resetToken;
+
+    @Column(name = "reset_token_expiry")
+    private LocalDateTime resetTokenExpiry;
+
     public Long getId() { return id; }
-    public String getUsername() { return username; }
-    public void setUsername(String username) { this.username = username; }
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
     public String getPasswordHash() { return passwordHash; }
     public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+    public String getResetToken() { return resetToken; }
+    public void setResetToken(String resetToken) { this.resetToken = resetToken; }
+    public LocalDateTime getResetTokenExpiry() { return resetTokenExpiry; }
+    public void setResetTokenExpiry(LocalDateTime resetTokenExpiry) { this.resetTokenExpiry = resetTokenExpiry; }
 }

--- a/backend/src/main/java/com/c15tour/backend/entity/User.java
+++ b/backend/src/main/java/com/c15tour/backend/entity/User.java
@@ -23,6 +23,9 @@ public class User {
     @Column(name = "reset_token_expiry")
     private LocalDateTime resetTokenExpiry;
 
+    @Column(name = "password_changed_at")
+    private Long passwordChangedAt;
+
     public Long getId() { return id; }
     public String getEmail() { return email; }
     public void setEmail(String email) { this.email = email; }
@@ -32,4 +35,6 @@ public class User {
     public void setResetToken(String resetToken) { this.resetToken = resetToken; }
     public LocalDateTime getResetTokenExpiry() { return resetTokenExpiry; }
     public void setResetTokenExpiry(LocalDateTime resetTokenExpiry) { this.resetTokenExpiry = resetTokenExpiry; }
+    public Long getPasswordChangedAt() { return passwordChangedAt; }
+    public void setPasswordChangedAt(Long passwordChangedAt) { this.passwordChangedAt = passwordChangedAt; }
 }

--- a/backend/src/main/java/com/c15tour/backend/repository/UserRepository.java
+++ b/backend/src/main/java/com/c15tour/backend/repository/UserRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    Optional<User> findByUsername(String username);
-    boolean existsByUsername(String username);
+    Optional<User> findByEmail(String email);
+    boolean existsByEmail(String email);
+    Optional<User> findByResetToken(String resetToken);
 }

--- a/backend/src/main/java/com/c15tour/backend/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/c15tour/backend/security/JwtAuthenticationFilter.java
@@ -1,5 +1,7 @@
 package com.c15tour.backend.security;
 
+import com.c15tour.backend.entity.User;
+import com.c15tour.backend.repository.UserRepository;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
@@ -12,14 +14,17 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.Optional;
 
 @Component
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtils jwtUtils;
+    private final UserRepository userRepository;
 
-    public JwtAuthenticationFilter(JwtUtils jwtUtils) {
+    public JwtAuthenticationFilter(JwtUtils jwtUtils, UserRepository userRepository) {
         this.jwtUtils = jwtUtils;
+        this.userRepository = userRepository;
     }
 
     @Override
@@ -37,15 +42,30 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 String username = jwtUtils.getUsername(token);
                 String role = jwtUtils.getRole(token);
 
-                var auth = new UsernamePasswordAuthenticationToken(
-                        username,
-                        null,
-                        List.of(new SimpleGrantedAuthority("ROLE_" + role))
-                );
-                SecurityContextHolder.getContext().setAuthentication(auth);
+                if (isTokenStillValidForUser(username, token)) {
+                    var auth = new UsernamePasswordAuthenticationToken(
+                            username,
+                            null,
+                            List.of(new SimpleGrantedAuthority("ROLE_" + role))
+                    );
+                    SecurityContextHolder.getContext().setAuthentication(auth);
+                }
             }
         }
 
         filterChain.doFilter(request, response);
+    }
+
+    private boolean isTokenStillValidForUser(String email, String token) {
+        Optional<User> dbUser = userRepository.findByEmail(email);
+        if (dbUser.isEmpty()) {
+            return true;
+        }
+        Long passwordChangedAt = dbUser.get().getPasswordChangedAt();
+        if (passwordChangedAt == null) {
+            return true;
+        }
+        long issuedAt = jwtUtils.getIssuedAtEpochSecond(token);
+        return issuedAt >= passwordChangedAt;
     }
 }

--- a/backend/src/main/java/com/c15tour/backend/security/JwtUtils.java
+++ b/backend/src/main/java/com/c15tour/backend/security/JwtUtils.java
@@ -41,6 +41,10 @@ public class JwtUtils {
         return parseClaims(token).get("role", String.class);
     }
 
+    public long getIssuedAtEpochSecond(String token) {
+        return parseClaims(token).getIssuedAt().toInstant().getEpochSecond();
+    }
+
     public boolean isValid(String token) {
         try {
             parseClaims(token);

--- a/backend/src/main/java/com/c15tour/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/c15tour/backend/security/SecurityConfig.java
@@ -35,7 +35,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf.disable())
                 .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/auth/login", "/auth/register", "/error").permitAll()
+                        .requestMatchers("/auth/login", "/auth/register", "/auth/forgot-password", "/auth/reset-password", "/error").permitAll()
 
                         .requestMatchers(HttpMethod.GET, "/tours/share/*").permitAll()
                         .requestMatchers(HttpMethod.POST, "/tours/*/route-to-start").permitAll()

--- a/backend/src/main/java/com/c15tour/backend/security/TokenHasher.java
+++ b/backend/src/main/java/com/c15tour/backend/security/TokenHasher.java
@@ -1,0 +1,21 @@
+package com.c15tour.backend.security;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+
+public final class TokenHasher {
+
+    private TokenHasher() {}
+
+    public static String sha256(String input) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+}

--- a/backend/src/main/java/com/c15tour/backend/service/MailjetEmailService.java
+++ b/backend/src/main/java/com/c15tour/backend/service/MailjetEmailService.java
@@ -1,0 +1,76 @@
+package com.c15tour.backend.service;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+public class MailjetEmailService {
+
+    private static final Logger logger = LoggerFactory.getLogger(MailjetEmailService.class);
+    private final RestClient restClient;
+    private final String fromEmail;
+
+    public MailjetEmailService(
+            @Value("${mailjet.api-key}") String apiKey,
+            @Value("${mailjet.secret-key}") String secretKey,
+            @Value("${mailjet.from-email}") String fromEmail) {
+        this.fromEmail = fromEmail;
+
+        String basicAuth = "Basic " + Base64.getEncoder()
+                .encodeToString((apiKey + ":" + secretKey).getBytes(StandardCharsets.UTF_8));
+
+        this.restClient = RestClient.builder()
+                .baseUrl("https://api.mailjet.com")
+                .defaultHeader("Authorization", basicAuth)
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
+
+    public void sendPasswordResetEmail(String toEmail, String resetUrl) {
+        try {
+            Map<String, Object> request = new HashMap<>();
+
+            Map<String, Object> message = new HashMap<>();
+
+            Map<String, String> from = new HashMap<>();
+            from.put("Email", fromEmail);
+            from.put("Name", "C15Tour");
+            message.put("From", from);
+
+            Map<String, String> to = new HashMap<>();
+            to.put("Email", toEmail);
+            message.put("To", List.of(to));
+
+            message.put("Subject", "Réinitialisation de votre mot de passe");
+            message.put("HTMLPart",
+                    "<p>Bonjour,</p>" +
+                    "<p>Cliquez sur le lien ci-dessous pour réinitialiser votre mot de passe (valable 1 heure) :</p>" +
+                    "<p><a href='" + resetUrl + "'>Réinitialiser mon mot de passe</a></p>" +
+                    "<p>Si vous n'avez pas fait cette demande, ignorez cet email.</p>");
+            message.put("TextPart",
+                    "Pour réinitialiser votre mot de passe, accédez à ce lien (valable 1 heure): " + resetUrl);
+
+            request.put("Messages", List.of(message));
+
+            restClient.post()
+                    .uri("/v3.1/send")
+                    .body(request)
+                    .retrieve()
+                    .body(String.class);
+
+            logger.info("Password reset email sent to {}", toEmail);
+        } catch (RestClientException e) {
+            logger.warn("Failed to send password reset email to {}: {}", toEmail, e.getMessage());
+        }
+    }
+}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -11,7 +11,8 @@ spring:
       ddl-auto: none
     show-sql: true
 
-# -- Mailjet (dev defaults - use env vars in prod)
+# -- Mailjet : définir MAILJET_API_KEY et MAILJET_SECRET_KEY dans l'environnement local
+# Ne jamais committer les clés en dur ici — utiliser un .env ou les variables d'env du système
 mailjet:
-  api-key: ${MAILJET_API_KEY:0c08206ad86dd191024fce953206f899}
-  secret-key: ${MAILJET_SECRET_KEY:794dad8392839d233fd5371fc9f2fbf6}
+  api-key: ${MAILJET_API_KEY}
+  secret-key: ${MAILJET_SECRET_KEY}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -10,9 +10,3 @@ spring:
     hibernate:
       ddl-auto: none
     show-sql: true
-
-# -- Mailjet : définir MAILJET_API_KEY et MAILJET_SECRET_KEY dans l'environnement local
-# Ne jamais committer les clés en dur ici — utiliser un .env ou les variables d'env du système
-mailjet:
-  api-key: ${MAILJET_API_KEY}
-  secret-key: ${MAILJET_SECRET_KEY}

--- a/backend/src/main/resources/application-dev.yml
+++ b/backend/src/main/resources/application-dev.yml
@@ -10,3 +10,8 @@ spring:
     hibernate:
       ddl-auto: none
     show-sql: true
+
+# -- Mailjet (dev defaults - use env vars in prod)
+mailjet:
+  api-key: ${MAILJET_API_KEY:0c08206ad86dd191024fce953206f899}
+  secret-key: ${MAILJET_SECRET_KEY:794dad8392839d233fd5371fc9f2fbf6}

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,6 +23,6 @@ app:
 
 # ── Mailjet ──
 mailjet:
-  api-key: ${MAILJET_API_KEY}
-  secret-key: ${MAILJET_SECRET_KEY}
+  api-key: ${MAILJET_API_KEY:}
+  secret-key: ${MAILJET_SECRET_KEY:}
   from-email: noreply@c15tour.com

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -16,8 +16,13 @@ audio:
 # ── Security ──
 app:
   security:
-    admin-username: ${ADMIN_USERNAME:admin}
-    admin-password: ${ADMIN_PASSWORD:admin}
     jwt-secret: ${JWT_SECRET:changeMeInProductionThisKeyMustBeAtLeast256BitsLong!!}
     jwt-expiration-ms: 86400000  # 24 heures
+  frontend:
+    url: ${FRONTEND_URL:http://localhost}
 
+# ── Mailjet ──
+mailjet:
+  api-key: ${MAILJET_API_KEY}
+  secret-key: ${MAILJET_SECRET_KEY}
+  from-email: noreply@c15tour.com

--- a/backend/src/main/resources/db/migration/V16__Add_Email_And_Reset_Token_To_Users.sql
+++ b/backend/src/main/resources/db/migration/V16__Add_Email_And_Reset_Token_To_Users.sql
@@ -1,0 +1,7 @@
+ALTER TABLE users ADD COLUMN email VARCHAR(255);
+UPDATE users SET email = username WHERE email IS NULL;
+ALTER TABLE users ALTER COLUMN email SET NOT NULL;
+ALTER TABLE users ADD CONSTRAINT users_email_unique UNIQUE (email);
+ALTER TABLE users DROP COLUMN username;
+ALTER TABLE users ADD COLUMN reset_token VARCHAR(255);
+ALTER TABLE users ADD COLUMN reset_token_expiry TIMESTAMP;

--- a/backend/src/main/resources/db/migration/V17__Add_Index_On_Reset_Token.sql
+++ b/backend/src/main/resources/db/migration/V17__Add_Index_On_Reset_Token.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_users_reset_token ON users(reset_token);

--- a/backend/src/main/resources/db/migration/V18__Add_Password_Changed_At_And_Clear_Reset_Tokens.sql
+++ b/backend/src/main/resources/db/migration/V18__Add_Password_Changed_At_And_Clear_Reset_Tokens.sql
@@ -1,0 +1,2 @@
+ALTER TABLE users ADD COLUMN password_changed_at BIGINT;
+UPDATE users SET reset_token = NULL, reset_token_expiry = NULL;

--- a/backend/src/main/resources/db/migration/V18__Add_Password_Changed_At_And_Clear_Reset_Tokens.sql
+++ b/backend/src/main/resources/db/migration/V18__Add_Password_Changed_At_And_Clear_Reset_Tokens.sql
@@ -1,2 +1,2 @@
 ALTER TABLE users ADD COLUMN password_changed_at BIGINT;
-UPDATE users SET reset_token = NULL, reset_token_expiry = NULL;
+UPDATE users SET reset_token = NULL, reset_token_expiry = NULL WHERE reset_token IS NOT NULL;

--- a/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
@@ -2,6 +2,7 @@ package com.c15tour.backend.controller;
 
 import com.c15tour.backend.entity.User;
 import com.c15tour.backend.repository.UserRepository;
+import com.c15tour.backend.security.TokenHasher;
 import com.c15tour.backend.service.MailjetEmailService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,7 +90,7 @@ class AuthControllerTest {
         mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("email", "test@test.com", "password", "wrong"))))
+                                Map.of("email", "test@test.com", "password", "wrongpwd"))))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("Invalid credentials"));
     }
@@ -108,7 +109,7 @@ class AuthControllerTest {
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("email", "newuser@test.com", "password", "secret"))))
+                                Map.of("email", "newuser@test.com", "password", "secret12"))))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.token").isNotEmpty());
     }
@@ -120,7 +121,7 @@ class AuthControllerTest {
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("email", "taken@test.com", "password", "secret"))))
+                                Map.of("email", "taken@test.com", "password", "secret12"))))
                 .andExpect(status().isConflict());
     }
 
@@ -129,7 +130,25 @@ class AuthControllerTest {
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("email", "", "password", "secret"))))
+                                Map.of("email", "", "password", "secret12"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void register_WithInvalidEmailFormat_ShouldReturn400() throws Exception {
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "not-an-email", "password", "secret12"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void register_WithShortPassword_ShouldReturn400() throws Exception {
+        mockMvc.perform(post("/auth/register")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "ok@test.com", "password", "short"))))
                 .andExpect(status().isBadRequest());
     }
 
@@ -144,7 +163,7 @@ class AuthControllerTest {
 
     @Test
     void forgotPassword_WithExistingEmail_ShouldSendResetEmail() throws Exception {
-        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(mockUser("user@test.com", "pass")));
+        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(mockUser("user@test.com", "pass1234")));
         when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         mockMvc.perform(post("/auth/forgot-password")
@@ -158,30 +177,32 @@ class AuthControllerTest {
 
     @Test
     void resetPassword_WithValidToken_ShouldReturn200() throws Exception {
-        User user = mockUser("u@test.com", "old");
-        user.setResetToken("valid-token");
+        String rawToken = "valid-token";
+        User user = mockUser("u@test.com", "oldpass12");
+        user.setResetToken(TokenHasher.sha256(rawToken));
         user.setResetTokenExpiry(LocalDateTime.now().plusHours(1));
-        when(userRepository.findByResetToken("valid-token")).thenReturn(Optional.of(user));
+        when(userRepository.findByResetToken(TokenHasher.sha256(rawToken))).thenReturn(Optional.of(user));
         when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
 
         mockMvc.perform(post("/auth/reset-password")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("token", "valid-token", "newPassword", "newpass"))))
+                                Map.of("token", rawToken, "newPassword", "newpass12"))))
                 .andExpect(status().isOk());
     }
 
     @Test
     void resetPassword_WithExpiredToken_ShouldReturn400() throws Exception {
-        User user = mockUser("u@test.com", "old");
-        user.setResetToken("expired-token");
+        String rawToken = "expired-token";
+        User user = mockUser("u@test.com", "oldpass12");
+        user.setResetToken(TokenHasher.sha256(rawToken));
         user.setResetTokenExpiry(LocalDateTime.now().minusHours(1));
-        when(userRepository.findByResetToken("expired-token")).thenReturn(Optional.of(user));
+        when(userRepository.findByResetToken(TokenHasher.sha256(rawToken))).thenReturn(Optional.of(user));
 
         mockMvc.perform(post("/auth/reset-password")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("token", "expired-token", "newPassword", "newpass"))))
+                                Map.of("token", rawToken, "newPassword", "newpass12"))))
                 .andExpect(status().isBadRequest());
     }
 
@@ -190,7 +211,7 @@ class AuthControllerTest {
         mockMvc.perform(post("/auth/reset-password")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("token", "bad-token", "newPassword", "newpass"))))
+                                Map.of("token", "bad-token", "newPassword", "newpass12"))))
                 .andExpect(status().isBadRequest());
     }
 
@@ -199,12 +220,12 @@ class AuthControllerTest {
         mockMvc.perform(post("/auth/change-password")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("currentPassword", "x", "newPassword", "y"))))
+                                Map.of("currentPassword", "x", "newPassword", "newpass12"))))
                 .andExpect(status().isForbidden());
     }
 
     @Test
-    void changePassword_WithValidAuth_ShouldReturn200() throws Exception {
+    void changePassword_WithValidAuth_ShouldReturn200WithNewToken() throws Exception {
         User user = mockUser("auth@test.com", "currentPass");
         when(userRepository.findByEmail("auth@test.com")).thenReturn(Optional.of(user));
         when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
@@ -214,7 +235,8 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 Map.of("currentPassword", "currentPass", "newPassword", "newPass123"))))
-                .andExpect(status().isOk());
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.token").isNotEmpty());
     }
 
     @Test
@@ -226,7 +248,7 @@ class AuthControllerTest {
                         .header("Authorization", "Bearer " + token)
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("currentPassword", "wrong", "newPassword", "newPass123"))))
+                                Map.of("currentPassword", "wrongpwd", "newPassword", "newPass123"))))
                 .andExpect(status().isUnauthorized());
     }
 
@@ -241,5 +263,20 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(
                                 Map.of("currentPassword", "currentPass", "newPassword", ""))))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void authenticatedRequest_AfterPasswordChange_ShouldRejectOldToken() throws Exception {
+        String oldToken = jwtUtils.generateToken("rotated@test.com", "ADMIN");
+        User user = mockUser("rotated@test.com", "currentPass");
+        user.setPasswordChangedAt(Long.MAX_VALUE);
+        when(userRepository.findByEmail("rotated@test.com")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(post("/auth/change-password")
+                        .header("Authorization", "Bearer " + oldToken)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("currentPassword", "currentPass", "newPassword", "newPass123"))))
+                .andExpect(status().isForbidden());
     }
 }

--- a/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
@@ -52,6 +52,9 @@ class AuthControllerTest {
     @MockitoBean
     private com.c15tour.backend.service.RoutingService routingService;
 
+    @Autowired
+    private com.c15tour.backend.security.JwtUtils jwtUtils;
+
     @BeforeEach
     void setUp() {
         when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
@@ -198,5 +201,45 @@ class AuthControllerTest {
                         .content(objectMapper.writeValueAsString(
                                 Map.of("currentPassword", "x", "newPassword", "y"))))
                 .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void changePassword_WithValidAuth_ShouldReturn200() throws Exception {
+        User user = mockUser("auth@test.com", "currentPass");
+        when(userRepository.findByEmail("auth@test.com")).thenReturn(Optional.of(user));
+        when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+        String token = jwtUtils.generateToken("auth@test.com", "ADMIN");
+        mockMvc.perform(post("/auth/change-password")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("currentPassword", "currentPass", "newPassword", "newPass123"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void changePassword_WithWrongCurrentPassword_ShouldReturn401() throws Exception {
+        User user = mockUser("auth@test.com", "currentPass");
+        when(userRepository.findByEmail("auth@test.com")).thenReturn(Optional.of(user));
+        String token = jwtUtils.generateToken("auth@test.com", "ADMIN");
+        mockMvc.perform(post("/auth/change-password")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("currentPassword", "wrong", "newPassword", "newPass123"))))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void changePassword_WithBlankNewPassword_ShouldReturn400() throws Exception {
+        User user = mockUser("auth@test.com", "currentPass");
+        when(userRepository.findByEmail("auth@test.com")).thenReturn(Optional.of(user));
+        String token = jwtUtils.generateToken("auth@test.com", "ADMIN");
+        mockMvc.perform(post("/auth/change-password")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("currentPassword", "currentPass", "newPassword", ""))))
+                .andExpect(status().isBadRequest());
     }
 }

--- a/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
@@ -49,6 +49,9 @@ class AuthControllerTest {
     @MockitoBean
     private UserRepository userRepository;
 
+    @MockitoBean
+    private com.c15tour.backend.service.RoutingService routingService;
+
     @BeforeEach
     void setUp() {
         when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());

--- a/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
@@ -1,7 +1,8 @@
 package com.c15tour.backend.controller;
 
+import com.c15tour.backend.entity.User;
 import com.c15tour.backend.repository.UserRepository;
-import com.c15tour.backend.service.RoutingService;
+import com.c15tour.backend.service.MailjetEmailService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -9,15 +10,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.Optional;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -28,10 +31,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
     com.c15tour.backend.security.JwtUtils.class
 })
 @TestPropertySource(properties = {
-    "app.security.admin-username=admin",
-    "app.security.admin-password=admin",
     "app.security.jwt-secret=changeMeInProductionThisKeyMustBeAtLeast256BitsLong!!",
-    "app.security.jwt-expiration-ms=86400000"
+    "app.security.jwt-expiration-ms=86400000",
+    "app.frontend.url=http://localhost"
 })
 class AuthControllerTest {
 
@@ -42,82 +44,156 @@ class AuthControllerTest {
     private ObjectMapper objectMapper;
 
     @MockitoBean
-    private RoutingService routingService;
+    private MailjetEmailService mailjetEmailService;
 
     @MockitoBean
     private UserRepository userRepository;
 
     @BeforeEach
     void setUp() {
-        when(userRepository.findByUsername(anyString())).thenReturn(Optional.empty());
-        when(userRepository.existsByUsername(anyString())).thenReturn(false);
+        when(userRepository.findByEmail(anyString())).thenReturn(Optional.empty());
+        when(userRepository.existsByEmail(anyString())).thenReturn(false);
+        when(userRepository.findByResetToken(anyString())).thenReturn(Optional.empty());
+        doNothing().when(mailjetEmailService).sendPasswordResetEmail(anyString(), anyString());
+    }
+
+    private User mockUser(String email, String rawPassword) {
+        User user = new User();
+        user.setEmail(email);
+        user.setPasswordHash(new BCryptPasswordEncoder().encode(rawPassword));
+        return user;
     }
 
     @Test
-    void login_WithValidAdminCredentials_ShouldReturn200WithToken() throws Exception {
+    void login_WithValidEmailCredentials_ShouldReturn200WithToken() throws Exception {
+        when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(mockUser("test@test.com", "password")));
+
         mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("username", "admin", "password", "admin"))))
+                                Map.of("email", "test@test.com", "password", "password"))))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.token").isNotEmpty());
     }
 
     @Test
     void login_WithWrongPassword_ShouldReturn401() throws Exception {
+        when(userRepository.findByEmail("test@test.com")).thenReturn(Optional.of(mockUser("test@test.com", "password")));
+
         mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("username", "admin", "password", "wrong"))))
+                                Map.of("email", "test@test.com", "password", "wrong"))))
                 .andExpect(status().isUnauthorized())
                 .andExpect(jsonPath("$.error").value("Invalid credentials"));
     }
 
     @Test
-    void login_WithWrongUsername_ShouldReturn401() throws Exception {
+    void login_WithUnknownEmail_ShouldReturn401() throws Exception {
         mockMvc.perform(post("/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("username", "hacker", "password", "admin"))))
+                                Map.of("email", "unknown@test.com", "password", "password"))))
                 .andExpect(status().isUnauthorized());
     }
 
     @Test
-    void register_WithNewUsername_ShouldReturn201WithToken() throws Exception {
+    void register_WithNewEmail_ShouldReturn201WithToken() throws Exception {
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("username", "newuser", "password", "secret"))))
+                                Map.of("email", "newuser@test.com", "password", "secret"))))
                 .andExpect(status().isCreated())
                 .andExpect(jsonPath("$.token").isNotEmpty());
     }
 
     @Test
-    void register_WithAdminUsername_ShouldReturn409() throws Exception {
+    void register_WithExistingEmail_ShouldReturn409() throws Exception {
+        when(userRepository.existsByEmail("taken@test.com")).thenReturn(true);
+
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("username", "admin", "password", "secret"))))
+                                Map.of("email", "taken@test.com", "password", "secret"))))
                 .andExpect(status().isConflict());
     }
 
     @Test
-    void register_WithExistingUsername_ShouldReturn409() throws Exception {
-        when(userRepository.existsByUsername("taken")).thenReturn(true);
-
+    void register_WithBlankEmail_ShouldReturn400() throws Exception {
         mockMvc.perform(post("/auth/register")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
-                                Map.of("username", "taken", "password", "secret"))))
-                .andExpect(status().isConflict());
-    }
-
-    @Test
-    void register_WithBlankUsername_ShouldReturn400() throws Exception {
-        mockMvc.perform(post("/auth/register")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content(objectMapper.writeValueAsString(
-                                Map.of("username", "", "password", "secret"))))
+                                Map.of("email", "", "password", "secret"))))
                 .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void forgotPassword_WithUnknownEmail_ShouldAlwaysReturn200() throws Exception {
+        mockMvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "nobody@test.com"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void forgotPassword_WithExistingEmail_ShouldSendResetEmail() throws Exception {
+        when(userRepository.findByEmail("user@test.com")).thenReturn(Optional.of(mockUser("user@test.com", "pass")));
+        when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        mockMvc.perform(post("/auth/forgot-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("email", "user@test.com"))))
+                .andExpect(status().isOk());
+
+        verify(mailjetEmailService).sendPasswordResetEmail(eq("user@test.com"), anyString());
+    }
+
+    @Test
+    void resetPassword_WithValidToken_ShouldReturn200() throws Exception {
+        User user = mockUser("u@test.com", "old");
+        user.setResetToken("valid-token");
+        user.setResetTokenExpiry(LocalDateTime.now().plusHours(1));
+        when(userRepository.findByResetToken("valid-token")).thenReturn(Optional.of(user));
+        when(userRepository.save(any())).thenAnswer(inv -> inv.getArgument(0));
+
+        mockMvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("token", "valid-token", "newPassword", "newpass"))))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void resetPassword_WithExpiredToken_ShouldReturn400() throws Exception {
+        User user = mockUser("u@test.com", "old");
+        user.setResetToken("expired-token");
+        user.setResetTokenExpiry(LocalDateTime.now().minusHours(1));
+        when(userRepository.findByResetToken("expired-token")).thenReturn(Optional.of(user));
+
+        mockMvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("token", "expired-token", "newPassword", "newpass"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void resetPassword_WithInvalidToken_ShouldReturn400() throws Exception {
+        mockMvc.perform(post("/auth/reset-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("token", "bad-token", "newPassword", "newpass"))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void changePassword_WithoutAuth_ShouldReturn403() throws Exception {
+        mockMvc.perform(post("/auth/change-password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("currentPassword", "x", "newPassword", "y"))))
+                .andExpect(status().isForbidden());
     }
 }


### PR DESCRIPTION
## Summary

- **Login/Register par email** : remplacement de `username` par `email` dans toute la chaîne auth (entité, repo, controller). Suppression du chemin admin hardcodé — toute connexion passe désormais par la base de données.
- **Nouveaux endpoints** :
  - `POST /auth/change-password` (protégé JWT) : change le mot de passe de l'utilisateur connecté
  - `POST /auth/forgot-password` (public) : génère un token UUID, le stocke en base avec une expiration 1h, envoie un email via Mailjet
  - `POST /auth/reset-password` (public) : valide le token, met à jour le mot de passe, invalide le token
- **MailjetEmailService** : nouveau service Spring utilisant `RestClient` (pas de dépendance supplémentaire) pour envoyer les emails de reset via l'API Mailjet v3.1
- **Migration Flyway V16** : colonne `username` → `email` (avec backfill), ajout `reset_token` + `reset_token_expiry`
- **Config** : suppression des credentials admin hardcodés, ajout de la config Mailjet (clés via `MAILJET_API_KEY` / `MAILJET_SECRET_KEY` en prod, valeurs dev dans `application-dev.yml`)

## Contexte

Répond aux besoins de la PR webapp [c15-tour-webapp#117](https://github.com/Elessiah-sTeam/c15-tour-webapp/pull/117) qui implémente : login email, modal paramètres compte (change-password + logout), pages forgot-password et reset-password.

## Test plan

- [ ] `POST /auth/register` avec `{ email, password }` → 201 + token JWT
- [ ] `POST /auth/login` avec `{ email, password }` → 200 + token JWT
- [ ] `POST /auth/login` avec mauvais mot de passe → 401
- [ ] `POST /auth/forgot-password` avec email inexistant → 200 (anti-énumération)
- [ ] `POST /auth/forgot-password` avec email existant → 200 + email Mailjet envoyé
- [ ] `POST /auth/reset-password` avec token valide → 200, mot de passe mis à jour
- [ ] `POST /auth/reset-password` avec token expiré → 400
- [ ] `POST /auth/change-password` avec JWT + bon mot de passe actuel → 200
- [ ] `POST /auth/change-password` sans JWT → 403
- [ ] `mvn test` → tous les tests passent (11 tests AuthControllerTest)
- [ ] Migration Flyway V16 appliquée sans erreur au démarrage

🤖 Generated with [Claude Code](https://claude.com/claude-code)