### PR TITLE
feat: add mobile redirect endpoint using OSRM table + route

### DIFF
--- a/backend/src/main/java/com/c15tour/backend/controller/MobileTourController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/MobileTourController.java
@@ -7,6 +7,8 @@ import com.c15tour.backend.service.MobileTourService;
 import com.c15tour.model.AudioMessageResponse;
 import com.c15tour.model.JoinResponse;
 import com.c15tour.model.OrganiserPositionRequest;
+import com.c15tour.model.RedirectRequest;
+import com.c15tour.model.RouteToStartResponse;
 import org.springframework.core.io.Resource;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -60,6 +62,17 @@ public class MobileTourController implements MobileApi {
     @Override
     public ResponseEntity<List<AudioMessageResponse>> getAudioMessages(String code) {
         return ResponseEntity.ok(audioMessageService.getHistory(code));
+    }
+
+    @Override
+    public ResponseEntity<RouteToStartResponse> redirectToTour(String code, RedirectRequest redirectRequest) {
+        RouteToStartResponse response = mobileTourService.redirect(
+                code,
+                redirectRequest.getLatitude(),
+                redirectRequest.getLongitude(),
+                redirectRequest.getLastReachedWaypointIndex()
+        );
+        return ResponseEntity.ok(response);
     }
 
     @Override

--- a/backend/src/main/java/com/c15tour/backend/security/SecurityConfig.java
+++ b/backend/src/main/java/com/c15tour/backend/security/SecurityConfig.java
@@ -44,7 +44,8 @@ public class SecurityConfig {
                                 "/tours/share/*/join",
                                 "/tours/share/*/organiser-position",
                                 "/tours/share/*/organiser-position/stream",
-                                "/tours/share/*/audio-messages"
+                                "/tours/share/*/audio-messages",
+                                "/tours/share/*/redirect"
                         ).permitAll()
 
                         .requestMatchers(HttpMethod.GET, "/audio/*").permitAll()

--- a/backend/src/main/java/com/c15tour/backend/service/MobileTourService.java
+++ b/backend/src/main/java/com/c15tour/backend/service/MobileTourService.java
@@ -1,9 +1,16 @@
 package com.c15tour.backend.service;
 
+import com.c15tour.backend.entity.Segment;
 import com.c15tour.backend.entity.Tour;
+import com.c15tour.backend.entity.Waypoint;
 import com.c15tour.backend.repository.TourRepository;
+import com.c15tour.backend.service.osrm.OSRMResponse;
+import com.c15tour.backend.service.osrm.OSRMTableResponse;
+import com.c15tour.model.Coordinates;
 import com.c15tour.model.JoinResponse;
 import com.c15tour.model.OrganiserPositionRequest;
+import com.c15tour.model.RouteToStartResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
@@ -12,6 +19,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -21,11 +29,19 @@ import java.util.concurrent.CopyOnWriteArrayList;
 @Service
 public class MobileTourService {
 
+    private static final int REDIRECT_CANDIDATE_COUNT = 5;
+
     private final TourRepository tourRepository;
+    private final RoutingService routingService;
+    private final ObjectMapper objectMapper;
     private final Map<Long, List<SseEmitter>> emitters = new ConcurrentHashMap<>();
 
-    public MobileTourService(TourRepository tourRepository) {
+    public MobileTourService(TourRepository tourRepository,
+                             RoutingService routingService,
+                             ObjectMapper objectMapper) {
         this.tourRepository = tourRepository;
+        this.routingService = routingService;
+        this.objectMapper = objectMapper;
     }
 
     public JoinResponse join(String code) {
@@ -125,5 +141,92 @@ public class MobileTourService {
         if (tourEmitters != null) {
             tourEmitters.remove(emitter);
         }
+    }
+
+    public RouteToStartResponse redirect(String shareCode, double lat, double lng, Integer lastReachedWaypointIndex) {
+        Tour tour = tourRepository.findByShareCode(shareCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Tour not found"));
+
+        List<Waypoint> allWaypoints = tour.getSegments().stream()
+                .sorted(Comparator.comparingInt(Segment::getOrderIndex))
+                .flatMap(s -> s.getWaypoints().stream()
+                        .sorted(Comparator.comparingInt(Waypoint::getOrderIndex)))
+                .toList();
+
+        int skipCount = (lastReachedWaypointIndex != null) ? lastReachedWaypointIndex + 1 : 0;
+        List<Waypoint> candidates = allWaypoints.stream()
+                .skip(skipCount)
+                .limit(REDIRECT_CANDIDATE_COUNT)
+                .toList();
+
+        if (candidates.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "No remaining waypoints");
+        }
+
+        Coordinates origin = new Coordinates();
+        origin.setLatitude(lat);
+        origin.setLongitude(lng);
+
+        List<Coordinates> destinations = candidates.stream().map(w -> {
+            Coordinates c = new Coordinates();
+            c.setLatitude(w.getLatitude());
+            c.setLongitude(w.getLongitude());
+            return c;
+        }).toList();
+
+        Waypoint target;
+        if (candidates.size() == 1) {
+            target = candidates.getFirst();
+        } else {
+            OSRMTableResponse table = routingService.calculateTable(origin, destinations);
+            if (table == null || table.durations() == null || table.durations().isEmpty()) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Could not compute durations");
+            }
+            List<Double> durations = table.durations().getFirst();
+            int bestIndex = 0;
+            Double bestDuration = null;
+            for (int i = 0; i < durations.size(); i++) {
+                Double d = durations.get(i);
+                if (d != null && (bestDuration == null || d < bestDuration)) {
+                    bestDuration = d;
+                    bestIndex = i;
+                }
+            }
+            target = candidates.get(bestIndex);
+        }
+
+        Coordinates targetCoords = new Coordinates();
+        targetCoords.setLatitude(target.getLatitude());
+        targetCoords.setLongitude(target.getLongitude());
+
+        OSRMResponse osrmResponse = routingService.calculateRoute(List.of(origin, targetCoords), true);
+        if (osrmResponse == null || osrmResponse.routes() == null || osrmResponse.routes().isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Could not compute route");
+        }
+
+        var route = osrmResponse.routes().getFirst();
+        RouteToStartResponse response = new RouteToStartResponse();
+        response.setDistance(route.distance() != null ? (long) Math.round(route.distance()) : 0L);
+        response.setDuration(route.duration() != null ? (long) Math.round(route.duration()) : 0L);
+
+        try {
+            response.setGeometry(objectMapper.writeValueAsString(route.geometry()));
+            if (route.legs() != null) {
+                List<OSRMResponse.Step> allSteps = route.legs().stream()
+                        .filter(leg -> leg.steps() != null)
+                        .flatMap(leg -> leg.steps().stream())
+                        .toList();
+                response.setSteps(objectMapper.writeValueAsString(allSteps));
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        com.c15tour.model.Waypoints targetDto = new com.c15tour.model.Waypoints();
+        targetDto.setName(target.getName() != null ? target.getName() : "Waypoint");
+        targetDto.setCoordinates(targetCoords);
+        response.setStartPoint(targetDto);
+
+        return response;
     }
 }

--- a/backend/src/main/java/com/c15tour/backend/service/RoutingService.java
+++ b/backend/src/main/java/com/c15tour/backend/service/RoutingService.java
@@ -77,15 +77,14 @@ public class RoutingService {
 
         String destinationIndices = IntStream.rangeClosed(1, destinations.size())
                 .mapToObj(Integer::toString)
-                .collect(Collectors.joining(","));
+                .collect(Collectors.joining(";"));
+
+        // Build raw URI to prevent Spring from percent-encoding the semicolons in query params
+        String rawUri = "/table/v1/driving/" + coords + "?sources=0&destinations=" + destinationIndices;
 
         try {
             OSRMTableResponse response = restClient.get()
-                    .uri(uriBuilder -> uriBuilder
-                            .path("/table/v1/driving/{coords}")
-                            .queryParam("sources", "0")
-                            .queryParam("destinations", destinationIndices)
-                            .build(coords))
+                    .uri(rawUri)
                     .retrieve()
                     .body(OSRMTableResponse.class);
 

--- a/backend/src/main/java/com/c15tour/backend/service/RoutingService.java
+++ b/backend/src/main/java/com/c15tour/backend/service/RoutingService.java
@@ -1,12 +1,15 @@
 package com.c15tour.backend.service;
 
 import com.c15tour.backend.service.osrm.OSRMResponse;
+import com.c15tour.backend.service.osrm.OSRMTableResponse;
 import com.c15tour.model.Coordinates;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 @Service
 public class RoutingService {
@@ -55,5 +58,46 @@ public class RoutingService {
 
     public OSRMResponse calculateRoute(List<Coordinates> coordinatesList) {
         return calculateRoute(coordinatesList, false);
+    }
+
+    /**
+     * Calls OSRM Table API to get durations from a single origin to N destinations.
+     * Returns durations[0][i] = seconds from origin to destination i (null if unreachable).
+     */
+    public OSRMTableResponse calculateTable(Coordinates origin, List<Coordinates> destinations) {
+        if (destinations == null || destinations.isEmpty()) return null;
+
+        List<Coordinates> all = new java.util.ArrayList<>();
+        all.add(origin);
+        all.addAll(destinations);
+
+        String coords = all.stream()
+                .map(c -> c.getLongitude() + "," + c.getLatitude())
+                .collect(Collectors.joining(";"));
+
+        String destinationIndices = IntStream.rangeClosed(1, destinations.size())
+                .mapToObj(Integer::toString)
+                .collect(Collectors.joining(","));
+
+        try {
+            OSRMTableResponse response = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path("/table/v1/driving/{coords}")
+                            .queryParam("sources", "0")
+                            .queryParam("destinations", destinationIndices)
+                            .build(coords))
+                    .retrieve()
+                    .body(OSRMTableResponse.class);
+
+            if (response != null && "Ok".equalsIgnoreCase(response.code())) return response;
+            return null;
+
+        } catch (org.springframework.web.client.RestClientResponseException e) {
+            System.err.println("ERREUR HTTP OSRM Table : " + e.getStatusCode() + " - " + e.getResponseBodyAsString());
+            return null;
+        } catch (org.springframework.web.client.RestClientException e) {
+            System.err.println("ERREUR CLIENT OSRM Table : " + e.getMessage());
+            return null;
+        }
     }
 }

--- a/backend/src/main/java/com/c15tour/backend/service/osrm/OSRMTableResponse.java
+++ b/backend/src/main/java/com/c15tour/backend/service/osrm/OSRMTableResponse.java
@@ -1,0 +1,13 @@
+package com.c15tour.backend.service.osrm;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record OSRMTableResponse(
+        String code,
+        List<List<Double>> durations,
+        List<OSRMResponse.Waypoint> sources,
+        List<OSRMResponse.Waypoint> destinations
+) {}

--- a/contract/src/main/resources/openapi.yaml
+++ b/contract/src/main/resources/openapi.yaml
@@ -376,6 +376,45 @@ paths:
         '404':
           description: File not found
 
+  /tours/share/{code}/redirect:
+    post:
+      summary: Get best reroute from current position back to the tour
+      operationId: redirectToTour
+      tags:
+        - Mobile
+      parameters:
+        - name: code
+          in: path
+          required: true
+          description: "Share code of the tour"
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RedirectRequest'
+      responses:
+        '200':
+          description: Best reroute calculated
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RouteToStartResponse'
+        '400':
+          description: No remaining waypoints or OSRM error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Tour not found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+
   /tours/{id}/route-to-start:
     post:
       summary: Get route from current location to the start of the tour
@@ -693,6 +732,27 @@ components:
         createdAt:
           type: string
           format: date-time
+
+    RedirectRequest:
+      type: object
+      required:
+        - latitude
+        - longitude
+      properties:
+        latitude:
+          type: number
+          format: double
+          minimum: -90
+          maximum: 90
+        longitude:
+          type: number
+          format: double
+          minimum: -180
+          maximum: 180
+        lastReachedWaypointIndex:
+          type: integer
+          minimum: 0
+          description: Flat index of the last confirmed waypoint across all segments (0-based). Omit to consider all waypoints.
 
     RouteToStartResponse:
       type: object


### PR DESCRIPTION
POST /tours/share/{code}/redirect computes durations to the next 5 waypoints via OSRM Table API, picks the fastest, then routes there. Accepts optional lastReachedWaypointIndex to skip already-passed points.