### PR TITLE
feat: endpoint DELETE /auth/account (suppression de compte) (#145)

### DIFF
--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -109,6 +109,16 @@ public class AuthController {
                 "token", newToken));
     }
 
+    /**
+     * Supprime définitivement le compte de l'utilisateur authentifié.
+     * Le mot de passe courant est exigé pour confirmer l'action. Les convois
+     * appartenant à l'utilisateur (et leurs segments en cascade) sont supprimés
+     * avant le compte, le tout dans une transaction.
+     *
+     * @param request corps contenant le mot de passe de confirmation
+     * @param authentication contexte de sécurité de l'utilisateur courant
+     * @return 200 si supprimé, 401 si le mot de passe est incorrect, 404 si l'utilisateur est introuvable
+     */
     @DeleteMapping("/account")
     @Transactional
     public ResponseEntity<?> deleteAccount(@Valid @RequestBody DeleteAccountRequest request, Authentication authentication) {

--- a/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
+++ b/backend/src/main/java/com/c15tour/backend/controller/AuthController.java
@@ -2,10 +2,12 @@ package com.c15tour.backend.controller;
 
 import com.c15tour.backend.entity.Role;
 import com.c15tour.backend.entity.User;
+import com.c15tour.backend.repository.TourRepository;
 import com.c15tour.backend.repository.UserRepository;
 import com.c15tour.backend.security.JwtUtils;
 import com.c15tour.backend.security.TokenHasher;
 import com.c15tour.backend.service.MailjetEmailService;
+import org.springframework.transaction.annotation.Transactional;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
@@ -33,6 +35,7 @@ public class AuthController {
 
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
+    private final TourRepository tourRepository;
     private final PasswordEncoder passwordEncoder;
     private final MailjetEmailService mailjetEmailService;
     private final String frontendUrl;
@@ -40,11 +43,13 @@ public class AuthController {
     public AuthController(
             JwtUtils jwtUtils,
             UserRepository userRepository,
+            TourRepository tourRepository,
             PasswordEncoder passwordEncoder,
             MailjetEmailService mailjetEmailService,
             @Value("${app.frontend.url}") String frontendUrl) {
         this.jwtUtils = jwtUtils;
         this.userRepository = userRepository;
+        this.tourRepository = tourRepository;
         this.passwordEncoder = passwordEncoder;
         this.mailjetEmailService = mailjetEmailService;
         this.frontendUrl = frontendUrl;
@@ -104,6 +109,29 @@ public class AuthController {
                 "token", newToken));
     }
 
+    @DeleteMapping("/account")
+    @Transactional
+    public ResponseEntity<?> deleteAccount(@Valid @RequestBody DeleteAccountRequest request, Authentication authentication) {
+        String email = authentication.getName();
+        Optional<User> dbUser = userRepository.findByEmail(email);
+
+        if (dbUser.isEmpty()) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                    .body(Map.of("error", "User not found"));
+        }
+
+        User user = dbUser.get();
+        if (!passwordEncoder.matches(request.password(), user.getPasswordHash())) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(Map.of("error", "Password is incorrect"));
+        }
+
+        tourRepository.deleteAll(tourRepository.findByOwner(user));
+        userRepository.delete(user);
+
+        return ResponseEntity.ok(Map.of(MESSAGE_KEY, "Account deleted successfully"));
+    }
+
     @PostMapping("/forgot-password")
     public ResponseEntity<?> forgotPassword(@Valid @RequestBody ForgotPasswordRequest request) {
         Optional<User> dbUser = userRepository.findByEmail(request.email());
@@ -160,6 +188,9 @@ public class AuthController {
     public record ChangePasswordRequest(
             @NotBlank String currentPassword,
             @NotBlank @Size(min = MIN_PASSWORD_LENGTH) String newPassword) {}
+
+    public record DeleteAccountRequest(
+            @NotBlank String password) {}
 
     public record ForgotPasswordRequest(
             @NotBlank @Email String email) {}

--- a/backend/src/main/java/com/c15tour/backend/repository/TourRepository.java
+++ b/backend/src/main/java/com/c15tour/backend/repository/TourRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -16,6 +17,7 @@ public interface TourRepository extends JpaRepository<Tour, Long> {
     Optional<Tour> findByOrganiserSessionToken(String organiserSessionToken);
     boolean existsByShareCode(String shareCode);
     Page<Tour> findByOwner(User owner, Pageable pageable);
+    List<Tour> findByOwner(User owner);
     Optional<Tour> findByIdAndOwner(Long id, User owner);
     boolean existsByIdAndOwner(Long id, User owner);
 }

--- a/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
@@ -51,6 +51,9 @@ class AuthControllerTest {
     private UserRepository userRepository;
 
     @MockitoBean
+    private com.c15tour.backend.repository.TourRepository tourRepository;
+
+    @MockitoBean
     private com.c15tour.backend.service.RoutingService routingService;
 
     @Autowired

--- a/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
+++ b/backend/src/test/java/com/c15tour/backend/controller/AuthControllerTest.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -265,6 +266,63 @@ class AuthControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(
                                 Map.of("currentPassword", "currentPass", "newPassword", ""))))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void deleteAccount_WithoutAuth_ShouldReturn403() throws Exception {
+        mockMvc.perform(delete("/auth/account")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("password", "currentPass"))))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    void deleteAccount_WithValidAuth_ShouldReturn200AndDeleteUser() throws Exception {
+        User user = mockUser("auth@test.com", "currentPass");
+        when(userRepository.findByEmail("auth@test.com")).thenReturn(Optional.of(user));
+        when(tourRepository.findByOwner(user)).thenReturn(java.util.List.of());
+        String token = jwtUtils.generateToken("auth@test.com", "ADMIN");
+
+        mockMvc.perform(delete("/auth/account")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("password", "currentPass"))))
+                .andExpect(status().isOk());
+
+        verify(tourRepository).deleteAll(anyList());
+        verify(userRepository).delete(user);
+    }
+
+    @Test
+    void deleteAccount_WithWrongPassword_ShouldReturn401() throws Exception {
+        User user = mockUser("auth@test.com", "currentPass");
+        when(userRepository.findByEmail("auth@test.com")).thenReturn(Optional.of(user));
+        String token = jwtUtils.generateToken("auth@test.com", "ADMIN");
+
+        mockMvc.perform(delete("/auth/account")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("password", "wrongpwd"))))
+                .andExpect(status().isUnauthorized());
+
+        verify(userRepository, never()).delete(any());
+    }
+
+    @Test
+    void deleteAccount_WithBlankPassword_ShouldReturn400() throws Exception {
+        User user = mockUser("auth@test.com", "currentPass");
+        when(userRepository.findByEmail("auth@test.com")).thenReturn(Optional.of(user));
+        String token = jwtUtils.generateToken("auth@test.com", "ADMIN");
+
+        mockMvc.perform(delete("/auth/account")
+                        .header("Authorization", "Bearer " + token)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                Map.of("password", ""))))
                 .andExpect(status().isBadRequest());
     }
 


### PR DESCRIPTION
@
## Contexte
Lié à lissue front #145 (Compte : Supprimer un compte). Le front a besoin dun endpoint pour supprimer définitivement le compte de lutilisateur connecté.

## Changements
- `AuthController` : nouvel endpoint `DELETE /auth/account`, authentifié (non listé en `permitAll`).
  - Exige le mot de passe courant en confirmation (record `DeleteAccountRequest`).
  - Supprime les convois de lutilisateur (et leurs segments en cascade) puis le compte, dans une transaction (`@Transactional`).
  - Réponses : `200` succès, `401` mot de passe incorrect, `404` utilisateur introuvable, `403` sans authentification.
- `TourRepository` : ajout de `List<Tour> findByOwner(User owner)` (suppression par entité pour conserver la cascade JPA).

## Tests
`AuthControllerTest` : sans auth → 403, auth valide → 200 (+ vérifie suppression tours & user), mauvais mot de passe → 401, mot de passe vide → 400. (22 tests verts.)
@